### PR TITLE
Limit RGB values to 255

### DIFF
--- a/src/Color.php
+++ b/src/Color.php
@@ -43,9 +43,9 @@ class Color
      */
     public function __construct(int $red = 0, int $green = 0, int $blue = 0)
     {
-        $this->red = $red;
-        $this->green = $green;
-        $this->blue = $blue;
+        $this->red = $this->_limitRGB($red);
+        $this->green = $this->_limitRGB($green);
+        $this->blue = $this->_limitRGB($blue);
     }
 
     /**
@@ -187,5 +187,17 @@ class Color
     public function __toString()
     {
         return "({$this->red}, {$this->green}, {$this->blue})";
+    }
+
+    /**
+     * Return inital RGB value or limit to 255.
+     *
+     * @param int $value RGB value to limit.
+     * 
+     * @return int
+     */
+    private function _limitRGB(int $value): int
+    {
+        return $value >= 255 ? 255 : $value;
     }
 }

--- a/src/Color.php
+++ b/src/Color.php
@@ -43,9 +43,9 @@ class Color
      */
     public function __construct(int $red = 0, int $green = 0, int $blue = 0)
     {
-        $this->red = $this->_limitRGB($red);
-        $this->green = $this->_limitRGB($green);
-        $this->blue = $this->_limitRGB($blue);
+        $this->red = max(0, min(255, $red));
+        $this->green = max(0, min(255, $green));
+        $this->blue = max(0, min(255, $blue));
     }
 
     /**
@@ -187,17 +187,5 @@ class Color
     public function __toString()
     {
         return "({$this->red}, {$this->green}, {$this->blue})";
-    }
-
-    /**
-     * Return inital RGB value or limit to 255.
-     *
-     * @param int $value RGB value to limit.
-     * 
-     * @return int
-     */
-    private function _limitRGB(int $value): int
-    {
-        return $value >= 255 ? 255 : $value;
     }
 }

--- a/tests/constructors.php
+++ b/tests/constructors.php
@@ -17,9 +17,10 @@ test('it can be created', function () {
     ok($static->toString() === '(255, 254, 253)', 'colors are stored correctly statically');
 });
 
-test('it can be created and color limited to 255', function () {
-    $color = new Color(256, 257, 258);
-    
+test('it can limit RGBA colors', function () {
+    $color = new Color(256, 257, 258, 2.0);
+
+    ok($color->alpha === 1.0, 'colors alpha value limited to 1.0');
     ok($color->toString() === '(255, 255, 255)', 'colors are limited to 255');
 });
 

--- a/tests/constructors.php
+++ b/tests/constructors.php
@@ -17,6 +17,12 @@ test('it can be created', function () {
     ok($static->toString() === '(255, 254, 253)', 'colors are stored correctly statically');
 });
 
+test('it can be created and color limited to 255', function () {
+    $color = new Color(256, 257, 258);
+    
+    ok($color->toString() === '(255, 255, 255)', 'colors are limited to 255');
+});
+
 test('it can be created using ::random()', function () {
     $random = Color::random();
 


### PR DESCRIPTION
This PR limits the RGB value to `255` since there's really no point in setting values greater than the RGB limit, which is `255`, this limits the values by returning `255` for any value greater or equal to the RGB value limit.