### PR TITLE
feature: alpha support

### DIFF
--- a/src/Color.php
+++ b/src/Color.php
@@ -120,7 +120,7 @@ class Color
      */
     public static function new(int $red = 0, int $green = 0, int $blue = 0, int $alpha = 1.0): Color
     {
-        return new static($red, $green, $blue);
+        return new static($red, $green, $blue, $alpha);
     }
 
     /**

--- a/src/Color.php
+++ b/src/Color.php
@@ -90,10 +90,10 @@ class Color
      *
      * @return Color
      */
-    public static function random(): Color
+    public static function random(bool $alpha = false): Color
     {
         return new static(
-            rand(0, 255), rand(0, 255), rand(0, 255)
+            rand(0, 255), rand(0, 255), rand(0, 255), $alpha ? mt_rand() / mt_getrandmax() : 1.0
         );
     }
 

--- a/src/Color.php
+++ b/src/Color.php
@@ -35,13 +35,20 @@ class Color
     public int $blue;
 
     /**
+     * Colors alpha value.
+     * 
+     * @var float Float between 0.0 and 1.0.
+     */
+    public float $alpha;
+
+    /**
      * Class constructor.
      *
      * @param int $red   Integer between 0 and 255.
      * @param int $green Integer between 0 and 255.
      * @param int $blue  Integer between 0 and 255.
      */
-    public function __construct(int $red = 0, int $green = 0, int $blue = 0)
+    public function __construct(int $red = 0, int $green = 0, int $blue = 0, float $alpha = 1.0)
     {
         $this->red = $red;
         $this->green = $green;
@@ -111,7 +118,7 @@ class Color
      * 
      * @return Color
      */
-    public static function new(int $red = 0, int $green = 0, int $blue = 0): Color
+    public static function new(int $red = 0, int $green = 0, int $blue = 0, int $alpha = 1.0): Color
     {
         return new static($red, $green, $blue);
     }

--- a/src/Color.php
+++ b/src/Color.php
@@ -53,6 +53,7 @@ class Color
         $this->red = $red;
         $this->green = $green;
         $this->blue = $blue;
+        $this->alpha = $alpha;
     }
 
     /**
@@ -118,7 +119,7 @@ class Color
      * 
      * @return Color
      */
-    public static function new(int $red = 0, int $green = 0, int $blue = 0, int $alpha = 1.0): Color
+    public static function new(int $red = 0, int $green = 0, int $blue = 0, float $alpha = 1.0): Color
     {
         return new static($red, $green, $blue, $alpha);
     }
@@ -145,7 +146,8 @@ class Color
      */
     public static function distanceBetween(Color $start, Color $end): int
     {
-        return pow($start->red - $end->red, 2) +
+        return pow($start->alpha - $end->alpha, 2) +
+            pow($start->red - $end->red, 2) +
             pow($start->green - $end->green, 2) + 
             pow($start->blue - $end->blue, 2);
     }
@@ -193,6 +195,10 @@ class Color
      */
     public function __toString()
     {
+        if ($this->alpha !== 1.0) {
+            return "({$this->red}, {$this->green}, {$this->blue}, {$this->alpha})";    
+        }
+
         return "({$this->red}, {$this->green}, {$this->blue})";
     }
 }

--- a/tests/formatting.php
+++ b/tests/formatting.php
@@ -15,6 +15,11 @@ test('it can be formatted as a string', function () {
 
     ok($color->toString() === '(255, 254, 253)', 'correctly formats string');
     ok((string) $color === '(255, 254, 253)', 'correctly formats string using cast');
+
+    $color->alpha = 0.5;
+
+    ok($color->toString() === '(255, 254, 253, 0.5)', 'correctly formats string with alpha');
+    ok((string) $color === '(255, 254, 253, 0.5)', 'correctly formats string with alpha using cast');
 });
 
 test('it can be formatted as a hex', function () {


### PR DESCRIPTION
Closes #3.

> Should be noted that this only partially adds support for alpha. It does **not** convert RGBA to an 8-digit hex and 8-digit hex into RGBA.